### PR TITLE
show install-zef at help

### DIFF
--- a/libexec/p6env-help
+++ b/libexec/p6env-help
@@ -97,10 +97,11 @@ documentation_for() {
 print_summary() {
   local command="$1"
   local summary usage help
+  local longest_command_word_count=11
   eval "$(documentation_for "$command")"
 
   if [ -n "$summary" ]; then
-    printf "   %-9s   %s\n" "$command" "$summary"
+    printf "   %-${longest_command_word_count}s   %s\n" "$command" "$summary"
   fi
 }
 
@@ -151,7 +152,7 @@ if [ -z "$1" ] || [ "$1" == "p6env" ]; then
   [ -z "$usage" ] || exit
   echo
   echo "Some useful p6env commands are:"
-  print_summaries commands local global shell install uninstall rehash version versions which whence
+  print_summaries commands local global shell install uninstall rehash version versions which whence install-zef
   echo
   echo "See \`p6env help <command>' for information on a specific command."
   echo "For full documentation, see: https://github.com/skaji/p6env#readme"


### PR DESCRIPTION
## WHY?

Now, p6env don't show install-zef at help.

## BEFORE

```
p6env 1.1.1
Usage: p6env <command> [<args>]

Some useful p6env commands are:
   commands    List all available p6env commands
   local       Set or show the local application-specific Perl6 version
   global      Set or show the global Perl6 version
   shell       Set or show the shell-specific Perl6 version
   install     Install a Perl6 version using perl6-build
   uninstall   Uninstall a Perl6 version
   rehash      Rehash p6env shims (run this after installing executables)
   version     Show the current Perl6 version and its origin
   versions    List all Perl6 versions available to p6env
   which       Display the full path to an executable
   whence      List all Perl6 versions that contain the given executable

See `p6env help <command>' for information on a specific command.
For full documentation, see: https://github.com/skaji/p6env#readme
```


## AFTER

```
Usage: p6env <command> [<args>]

Some useful p6env commands are:
   commands      List all available p6env commands
   local         Set or show the local application-specific Perl6 version
   global        Set or show the global Perl6 version
   shell         Set or show the shell-specific Perl6 version
   install       Install a Perl6 version using perl6-build
   uninstall     Uninstall a Perl6 version
   rehash        Rehash p6env shims (run this after installing executables)
   version       Show the current Perl6 version and its origin
   versions      List all Perl6 versions available to p6env
   which         Display the full path to an executable
   whence        List all Perl6 versions that contain the given executable
   install-zef   Install zef from git repository

See `p6env help <command>' for information on a specific command.
For full documentation, see: https://github.com/skaji/p6env#readme
```