### PR TITLE
fix cache: unbound variable

### DIFF
--- a/libexec/rakuenv-install
+++ b/libexec/rakuenv-install
@@ -107,7 +107,7 @@ run() {
   for f in "$root/cache/rakudo-moar-$version"-*; do
     cache="$f"
   done
-  if [[ -z $cache ]]; then
+  if [[ -z "${cache:-}" ]]; then
     local download_url=$(download_url $version)
     if [[ -z $download_url ]]; then
       die "Unknown version '$version', try 'rakuenv install --list'"

--- a/libexec/rakuenv-install
+++ b/libexec/rakuenv-install
@@ -103,11 +103,11 @@ run() {
     die "Already exists $as"
   fi
 
-  local cache
+  local cache=
   for f in "$root/cache/rakudo-moar-$version"-*; do
     cache="$f"
   done
-  if [[ -z "${cache:-}" ]]; then
+  if [[ -z $cache ]]; then
     local download_url=$(download_url $version)
     if [[ -z $download_url ]]; then
       die "Unknown version '$version', try 'rakuenv install --list'"


### PR DESCRIPTION
# my environment

```
$bash --version
GNU bash, version 5.0.17(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2019 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

# problem

I executed install command.
But, happen errors.

```shell 
$ rakuenv install 2020.12-01
/home/anatofuz/.rakuenv/libexec/rakuenv-install: line 110: cache: unbound variable
```

## After applying the patch

I could install rakudo.

```shell
$ rakuenv install 2020.12-01
Downloading https://rakudo.org/dl/rakudo/rakudo-moar-2020.12-01-linux-x86_64-gcc.tar.gz
Extracting /home/anatofuz/.rakuenv/cache/rakudo-moar-2020.12-01-linux-x86_64-gcc.tar.gz
Successfully installed 2020.12-01
You may want to execute 'rakuenv global 2020.12-01'
$ rakuenv install 2020.12-01 --as test
Extracting /home/anatofuz/.rakuenv/cache/rakudo-moar-2020.12-01-linux-x86_64-gcc.tar.gz
Successfully installed test
You may want to execute 'rakuenv global test'
```